### PR TITLE
hotfix(deprectaed import): langchain => langchain_community

### DIFF
--- a/src/rag/rag.py
+++ b/src/rag/rag.py
@@ -1,4 +1,4 @@
-from langchain.document_loaders import TextLoader
+from langchain_community.document_loaders import TextLoader
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_chroma import Chroma
 from langchain_ollama.embeddings import OllamaEmbeddings


### PR DESCRIPTION
Langchain import is deprecated for TextLoader, i change for langchain community.